### PR TITLE
Replaced 'reference' with new 'placeid'

### DIFF
--- a/FTGooglePlacesAPI/FTGooglePlacesAPIDetailRequest.h
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPIDetailRequest.h
@@ -40,8 +40,9 @@
 /**
  *  Reference with which the request was initialized.
  *  This is a unique identifier for a place (itemId from the ResultItem)
+ *  See deprecation notice for 'reference replaced by placeid': https://developers.google.com/places/documentation/search#deprecatio
  */
-@property (nonatomic, strong, readonly) NSString *reference;
+@property (nonatomic, strong, readonly) NSString *placeId;
 
 - (instancetype)initWithReference:(NSString *)reference;
 

--- a/FTGooglePlacesAPI/FTGooglePlacesAPIDetailRequest.m
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPIDetailRequest.m
@@ -34,16 +34,16 @@
 
 #pragma mark Lifecycle
 
-- (instancetype)initWithReference:(NSString *)reference
+- (instancetype)initWithReference:(NSString *)placeId
 {
-    if ([reference length] == 0) {
+    if ([placeId length] == 0) {
         NSLog(@"WARNING: Trying to create FTGooglePlacesAPIDetailRequest with empty reference. Returning nil");
         return nil;
     }
     
     self = [super init];
     if (self) {
-        _reference = reference;
+        _placeId = placeId;
     }
     return self;
 }
@@ -52,7 +52,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p> Reference: %@", [self class], self, _reference];
+    return [NSString stringWithFormat:@"<%@: %p> PlaceId: %@", [self class], self, _placeId];
 }
 
 #pragma mark - FTGooglePlacesAPIRequest protocol
@@ -64,7 +64,7 @@
 
 - (NSDictionary *)placesAPIRequestParams
 {
-    return @{@"reference": _reference};
+    return @{@"placeid": _placeId};
 }
 
 @end

--- a/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.h
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.h
@@ -94,6 +94,13 @@
  *  token is not guaranteed to be returned for any given Place across different searches.
  */
 @property (nonatomic, strong, readonly) NSString *reference;
+/**
+ *
+ * See deprecation notice for 'reference replaced by placeid': https://developers.google.com/places/documentation/search#deprecation
+ *
+ */
+@property (nonatomic, strong, readonly) NSString *placeId;
+
 @property (nonatomic, strong, readonly) NSArray *types;
 @property (nonatomic, strong, readonly) NSURL *url;
 @property (nonatomic, strong, readonly) NSURL *websiteUrl;

--- a/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.m
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.m
@@ -96,7 +96,7 @@
     
     _iconImageUrl = [dictionary ftgp_nilledObjectForKey:@"icon"];
     _rating = [[dictionary ftgp_nilledObjectForKey:@"rating"] floatValue];
-    _placeId = [dictionary ftgp_nilledObjectForKey:@"placeid"];
+    _placeId = [dictionary ftgp_nilledObjectForKey:@"place_id"];
     _reference = [dictionary ftgp_nilledObjectForKey:@"reference"];
     _types = [dictionary ftgp_nilledObjectForKey:@"types"];
     

--- a/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.m
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.m
@@ -96,6 +96,7 @@
     
     _iconImageUrl = [dictionary ftgp_nilledObjectForKey:@"icon"];
     _rating = [[dictionary ftgp_nilledObjectForKey:@"rating"] floatValue];
+    _placeId = [dictionary ftgp_nilledObjectForKey:@"placeid"];
     _reference = [dictionary ftgp_nilledObjectForKey:@"reference"];
     _types = [dictionary ftgp_nilledObjectForKey:@"types"];
     

--- a/FTGooglePlacesAPI/FTGooglePlacesAPISearchResultItem.h
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPISearchResultItem.h
@@ -53,7 +53,15 @@ typedef NS_ENUM(NSUInteger, FTGooglePlacesAPISearchResultItemOpenedState) {
 @property (nonatomic, assign, readonly) FTGooglePlacesAPISearchResultItemOpenedState openedState;
 @property (nonatomic, strong, readonly) NSString *iconImageUrl;
 @property (nonatomic, assign, readonly) CGFloat rating;
+
+/**
+ *
+ * See deprecation notice for 'reference replaced by placeid': https://developers.google.com/places/documentation/search#deprecation
+ *
+ */
+@property (nonatomic, strong, readonly) NSString *placeId;
 @property (nonatomic, strong, readonly) NSString *reference;
+
 @property (nonatomic, strong, readonly) NSArray *types;
 
 /**

--- a/FTGooglePlacesAPI/FTGooglePlacesAPISearchResultItem.m
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPISearchResultItem.m
@@ -146,6 +146,7 @@
     
     _iconImageUrl = [dictionary ftgp_nilledObjectForKey:@"icon"];
     _rating = [[dictionary ftgp_nilledObjectForKey:@"rating"] floatValue];
+    _placeId = [dictionary ftgp_nilledObjectForKey:@"placeid"];
     _reference = [dictionary ftgp_nilledObjectForKey:@"reference"];
     _types = [dictionary ftgp_nilledObjectForKey:@"types"];
 }

--- a/FTGooglePlacesAPI/FTGooglePlacesAPISearchResultItem.m
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPISearchResultItem.m
@@ -146,7 +146,7 @@
     
     _iconImageUrl = [dictionary ftgp_nilledObjectForKey:@"icon"];
     _rating = [[dictionary ftgp_nilledObjectForKey:@"rating"] floatValue];
-    _placeId = [dictionary ftgp_nilledObjectForKey:@"placeid"];
+    _placeId = [dictionary ftgp_nilledObjectForKey:@"place_id"];
     _reference = [dictionary ftgp_nilledObjectForKey:@"reference"];
     _types = [dictionary ftgp_nilledObjectForKey:@"types"];
 }


### PR DESCRIPTION
See deprecation notice for 'reference replaced by placeid': https://developers.google.com/places/documentation/search#deprecation
