### PR TITLE
Adding an addressComponents array to the details response object

### DIFF
--- a/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.h
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.h
@@ -87,6 +87,8 @@
 @property (nonatomic, strong, readonly) NSString *iconImageUrl;
 @property (nonatomic, assign, readonly) CGFloat rating;
 
+@property (nonatomic, strong, readonly) NSArray *addressComponents;
+
 /**
  *  Contains a unique token that you can use to retrieve additional information
  *  about this place in a Place Details request. You can store this token and use

--- a/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.m
+++ b/FTGooglePlacesAPI/FTGooglePlacesAPIDetailResponse.m
@@ -86,7 +86,9 @@
         }
         
     }
-    
+  
+    _addressComponents = [dictionary ftgp_nilledObjectForKey:@"address_components"];
+  
     _addressString = [dictionary ftgp_nilledObjectForKey:@"vicinity"];
     
     _formattedAddress = [dictionary ftgp_nilledObjectForKey:@"formatted_address"];


### PR DESCRIPTION
I added a public facing, readonly property for the `addressComponents` of the details response object.  I needed more detailed analytics and UI behavior driven around certain locales and the information was not readily available in the existing API.
